### PR TITLE
- fix timezone

### DIFF
--- a/public/register.php
+++ b/public/register.php
@@ -6,6 +6,7 @@ use Blumilksoftware\Lmt\RegistrationEmailHandler;
 use Blumilksoftware\Lmt\TemplateRenderer;
 use Symfony\Component\Dotenv\Dotenv;
 
+date_default_timezone_set('Europe/Warsaw');
 $dotenv = new Dotenv();
 $dotenv->load(__DIR__."/../.env");
 


### PR DESCRIPTION
sets the timezone so that the date in emails is expressed in `Europe/Warsaw`