### PR TITLE
#30 - counter fix

### DIFF
--- a/public/application.js
+++ b/public/application.js
@@ -43,8 +43,6 @@ function initialize() {
                 const diff = moment(this.meetup.datetime).diff(now)
                 this.active = diff > 0
 
-                console.log(diff)
-
                 this.counters.days = String(Math.floor(moment.duration(diff).asDays())).padStart(2, "0")
                 this.counters.hours = String(moment.duration(diff).hours()).padStart(2, "0")
                 this.counters.minutes = String(moment.duration(diff).minutes()).padStart(2, "0")

--- a/public/application.js
+++ b/public/application.js
@@ -2,6 +2,7 @@ function initialize() {
     return {
         meetups: [],
         meetup: null,
+        active: false,
         selectedSpeaker: null,
         counters: {
             days: "00",
@@ -40,6 +41,9 @@ function initialize() {
             if (this.meetup) {
                 const now = moment()
                 const diff = moment(this.meetup.datetime).diff(now)
+                this.active = diff > 0
+
+                console.log(diff)
 
                 this.counters.days = String(Math.floor(moment.duration(diff).asDays())).padStart(2, "0")
                 this.counters.hours = String(moment.duration(diff).hours()).padStart(2, "0")

--- a/public/index.html
+++ b/public/index.html
@@ -112,8 +112,7 @@
           <span class="flex-grow px-2">Inteligentne rozwiązania, lokalne podejście</span>
           <div class="ml-20 bg-[#01FF6B] h-3 w-20"></div>
         </div>
-
-        <div class="hidden flex-shrink w-max-2xl bg-black bg-opacity-75 mt-20 px-4 py-6 rounded-2xl sm:flex divide-x divide-slate-100/25">
+        <div x-show="active" class="hidden flex-shrink w-max-2xl bg-black bg-opacity-75 mt-20 px-4 py-6 rounded-2xl sm:flex divide-x divide-slate-100/25">
           <div class="flex px-4">
             <div class="text-7xl font-bold text-[#01FF6B]" x-text="counters.days"></div>
             <div class="rotate-180 text-sm py-2">
@@ -139,7 +138,7 @@
             </div>
           </div>
         </div>
-        <div class="flex sm:hidden flex-wrap justify-center items-center mx-auto flex-col gap-4 mt-20 px-4 py-6 rounded-2xl">
+        <div x-show="active" class="flex sm:hidden flex-wrap justify-center items-center mx-auto flex-col gap-4 mt-20 px-4 py-6 rounded-2xl">
           <div class="flex flex-col items-center px-4">
             <div class="text-5xl font-bold text-[#01FF6B]" x-text="counters.days"></div>
             <div class="flex text-sm py-2">


### PR DESCRIPTION
Should close #30.
When the meeting start time is reached, the activity flag is set to `false` and hides the counter.

Preview:

[Screencast from 11-04-24 10:00:52.webm](https://github.com/blumilksoftware/lmt/assets/29115024/ce265fc5-0488-44c5-9135-e74b78b2f5c8)
