### PR TITLE
- add YouTube link to speaker presentation

### DIFF
--- a/public/assets/meetups/2024-09-12-lmt-02/data.json
+++ b/public/assets/meetups/2024-09-12-lmt-02/data.json
@@ -50,7 +50,7 @@
       "about": "Doktorant na Politechnice Opolskiej w dyscyplinie Informatyka Techniczna i Telekomunikacja, współwłaściciel Epicentrum Art Gallery w Opolu oraz firmy informatycznej IT Goal sp. z o.o. Jego zainteresowania to automatyzacja i robotyzacja procesów biznesowych, w tym z wykorzystaniem uczenia maszynowego.",
       "presentationTitle": "Przewidywanie wyników aukcyjnych dzieł sztuki",
       "presentationUrl": "patryk-mauer.pdf",
-      "videoUrl": ""
+      "videoUrl": "https://www.youtube.com/watch?v=_Drmd0U4Aco"
     }
   ],
   "agenda": [


### PR DESCRIPTION
This PR includes the addition of a YouTube link to a recording of one of the speakers' presentations. 