### PR TITLE
#106 - fix form submission

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -859,7 +859,7 @@
     </section>
     <section class="relative mt-[110px] lg:mt-48">
       <template x-if="meetup">
-        <div class="relative z-10 mx-auto max-w-6xl" id="rejestracja">
+        <div class="relative z-10 mx-auto max-w-6xl" id="rejestracja" x-init="htmx.process(document.body)">
           <div
             hx-ext="loading-states"
             data-loading-delay="300"


### PR DESCRIPTION
closes #106

my understanding of the issue is that on load, htmx scans the DOM and finds all `hx-*` attributes. But since the form got wrapped with a `<template x-if="...` it is not part of the DOM at that time
the effect is that htmx does not work inside the `<template>` but works outside of it

the fix here is to force htmx to scan the DOM again after the form section is shown
