### PR TITLE
- fix icon size

### DIFF
--- a/public/meetup.html
+++ b/public/meetup.html
@@ -407,7 +407,7 @@
                     >
                       <div class="flex items-center">
                         <svg
-                          class="mr-2 size-5"
+                          class="mr-2 size-5 flex-shrink-0"
                           viewBox="0 0 15 19"
                           fill="none"
                           xmlns="http://www.w3.org/2000/svg"
@@ -437,7 +437,7 @@
                     >
                       <div class="flex items-center">
                         <svg
-                          class="mr-2 size-5"
+                          class="mr-2 size-5 flex-shrink-0"
                           viewBox="0 0 18 15"
                           fill="none"
                           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Fixed icon size in the speakers section. Previously, when the presentation title was too long, the icon would shrink, affecting the layout. Now, the icon maintains its size.