### PR TITLE
- fix register form

### DIFF
--- a/app/Livewire/ContactForm.php
+++ b/app/Livewire/ContactForm.php
@@ -18,7 +18,7 @@ class ContactForm extends Component
     public ?string $email;
     public ?string $name;
     public ?string $surname;
-    public ?string $company;
+    public ?string $company = null;
     public bool $consent = false;
     public bool $success = false;
 


### PR DESCRIPTION
There was a bug - when user register to a meetup and doesn't fill input with company, he gets error 500, but user receives email that registration to meetup was successful. This pr fixes the bug :blush: